### PR TITLE
Rename deployment input to name

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -27,7 +27,7 @@ jobs:
         uses: ./
         with:
           namespace: github-actions
-          deployment: www
+          name: www
           container: nginx
           image: nginx:latest
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+env:
+  KUBECONFIG: ${{ github.workspace }}/__kubeconfig_tmp__
+
 jobs:
   self-test:
     name: Self-test
@@ -17,12 +20,8 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Get GKE credentials
-        uses: google-github-actions/get-gke-credentials@main
-        with:
-          cluster_name: ${{ secrets.GKE_CLUSTER_NAME }}
-          location: ${{ secrets.GKE_CLUSTER_LOCATION }}
-          credentials: ${{ secrets.GCP_SA_KEY }}
+      - name: Auth to cluster
+        run: echo ${{ secrets.KUBECONFIG }} | base64 -d > $KUBECONFIG
 
       - name: Run this action
         uses: ./

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This action will run the `kubectl` commands to deploy an image to Kubernetes, an
 |---|---|---|---|
 | `token` | **yes** | | Github Token (to create the Deployment record). Typically provide `${{ secrets.GITHUB_TOKEN }}`. |
 | `namespace` | no | | Namespace of the Kubernetes Deployment |
-| `deployment` | **yes** | | Deployment name |
+| `deployment` | no, *deprecated* | | Legacy version of `name`; use that input instead. This will be removed in the next major version. |
+| `name` | not yet | | Deployment name (this will be required in the next major version) |
 | `container` | **yes** | | Container name within the deployment |
 | `image` | **yes** | | Image to set in the container |
 | `environment` | **yes** | | Github environment name |

--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
   deployment:
     description: The Deployment to update.
     required: false
-    deprecationMessage: The `deployment` input has been deprecated in favor of `name`
+    deprecationMessage: Use 'name' instead.
   name:
     description: The name of the Deployment to update. (this field replaces `deployment` and will be required in the next major version)
     required: false

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,11 @@ inputs:
     required: false
   deployment:
     description: The Deployment to update.
-    required: true
+    required: false
+    deprecationMessage: The `deployment` input has been deprecated in favor of `name`
+  name:
+    description: The name of the Deployment to update. (this field replaces `deployment` and will be required in the next major version)
+    required: false
   container:
     description: The name of the Container in the Deployment that will have its image updated.
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -7684,8 +7684,14 @@ async function deploy() {
     if (namespace !== '') {
         args.push(`--namespace=${namespace}`);
     }
-    const deployment = core.getInput('deployment');
-    args.push(deployment);
+    let name = core.getInput('name');
+    if (name === '') {
+        name = core.getInput('deployment');
+    }
+    if (name === '') {
+        core.setFailed('`name` must not be empty.');
+    }
+    args.push(name);
     const container = core.getInput('container');
     const image = core.getInput('image');
     args.push(`${container}=${image}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,8 +91,14 @@ async function deploy(): Promise<void> {
     args.push(`--namespace=${namespace}`)
   }
 
-  const deployment = core.getInput('deployment')
-  args.push(deployment)
+  let name = core.getInput('name')
+  if (name === '') {
+    name = core.getInput('deployment')
+  }
+  if (name === '') {
+    core.setFailed('`name` must not be empty.')
+  }
+  args.push(name)
 
   const container = core.getInput('container')
   const image = core.getInput('image')


### PR DESCRIPTION
This will create a more versatile input format, in preparation for #10.