### PR TITLE
Avoid polluting action output with debug message

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -7711,7 +7711,7 @@ async function createDeploymentStatus(deploymentId, state) {
         environment_url,
     };
     const result = await ok.rest.repos.createDeploymentStatus(params);
-    console.debug(JSON.stringify(result));
+    core.debug(JSON.stringify(result));
 }
 run();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,8 +125,7 @@ async function createDeploymentStatus(deploymentId: number, state: DeploymentSta
     environment_url,
   }
   const result = await ok.rest.repos.createDeploymentStatus(params)
-  console.debug(JSON.stringify(result))
-
+  core.debug(JSON.stringify(result))
 }
 
 run()


### PR DESCRIPTION
Replace `console.debug` with `core.debug` to better align with action output needs.