### PR TITLE
Improve accuracy of GH statuses

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  push:
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Auth to GH registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+
+      - uses: firehed/multistage-docker-build-action@v1
+        with:
+          repository: ghcr.io/firehed/deploy-to-kubernetes-action
+          stages: ''
+          server-stage: server
+          build-args: COMMIT=${{ github.sha }}
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,6 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-
       - uses: firehed/multistage-docker-build-action@v1
         with:
           repository: ghcr.io/firehed/deploy-to-kubernetes-action

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Auth to GH registry
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -30,7 +30,7 @@ jobs:
           deployment: www
           container: nginx
           # image: nginx:latest
-          image: ghcr.io/firehed/deploy-to-kubernetes-action/server:${{ github.sha }}
+          image: ghcr.io/firehed/deploy-to-kubernetes-action/server:${{ github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           transient: ${{ github.event_name == 'pull_request' }}
           production: ${{ github.event_name == 'push' }}

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -37,6 +37,7 @@ jobs:
           environment: ${{ github.event_name == 'push' && 'production' || format('dev-{0}', github.ref) }}
 
       - name: Run w/ insufficient permission
+        if: always()
         uses: ./
         with:
           # no namespace ~ auth not good

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   self-test:
-    name: Self-test
+    name: Successes
     runs-on: ubuntu-latest
     steps:
 
@@ -37,53 +37,66 @@ jobs:
           url: https://example.com/${{ github.ref }}
           environment: ${{ github.event_name == 'push' && 'production' || format('dev-{0}', github.ref) }}
 
-      - name: Run w/ insufficient permission
-        if: always()
-        uses: ./
-        with:
-          # no namespace ~ auth not good
-          container: nginx
-          deployment: www
-          image: nginx:latest
-          token: ${{ secrets.GITHUB_TOKEN }}
-          environment: pr-selftest-nopermissions
+#       - name: Run w/out waiting
+#         uses: ./
+#         with:
+#           image: nginx:latest
+#           token: ${{ secrets.GITHUB_TOKEN }}
+#           url: https://example.com/${{ github.ref }}
+#           environment: pr-selftest-no-wait
+#           wait: false
 
-      - name: Run w/ incorrect deployment
-        if: always()
-        uses: ./
-        with:
-          # no namespace ~ auth not good
-          namespace: github-actions
-          container: nginx
-          deployment: fake
-          image: nginx:latest
-          token: ${{ secrets.GITHUB_TOKEN }}
-          environment: pr-selftest-incorrectdeploy
+#       - name: Run w/ very fast timeout
+#         uses: ./
+#         with:
+#           namespace: github-actions
+#           deployment: www
+#           container: nginx
+#           image: nginx:latest
+#           token: ${{ secrets.GITHUB_TOKEN }}
+#           transient: false
+#           production: false
+#           url: https://example.com/${{ github.ref }}
+#           environment: pr-selftest-fast-timeout
+#           wait-timeout: 2s
 
-      - name: Run w/out waiting
+  intentional-failures:
+    name: Failures
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      max-parallel: 1 # Avoid trampling actual cluster resource
+      matrix:
+        include:
+
+          - name: Permissions (namespace)
+            env: pr-selftest-nopermissions
+            namespace: incorrect
+
+          - name: Deploy does not exist
+            env: pr-selftest-nodeploy
+            deployment: fake
+
+          - name: Bad image
+            env: pr-selftest-badimage
+            image: ghcr.io/firehed/deploy-to-kubernetes-action/badname:${{ github.sha }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Authenticate to cluster
+        run: echo ${{ secrets.KUBECONFIG_LKE }} | base64 -d > $KUBECONFIG
+
+      - name: ${{ matrix.name }}
         uses: ./
         with:
-          namespace: github-actions
-          deployment: www
+          namespace: ${{ matrix.namespace || 'github-actions' }}
           container: nginx
-          image: nginx:latest
+          deployment: ${{ matrix.deployment || 'failtest' }}
+          image: ${{ matrix.image || 'nginx:latest' }}
           token: ${{ secrets.GITHUB_TOKEN }}
+          environment: ${{ matrix.env }}
           transient: false
           production: false
-          url: https://example.com/${{ github.ref }}
-          environment: pr-selftest-no-wait
-          wait: false
-
-      - name: Run w/ very fast timeout
-        uses: ./
-        with:
-          namespace: github-actions
-          deployment: www
-          container: nginx
-          image: nginx:latest
-          token: ${{ secrets.GITHUB_TOKEN }}
-          transient: false
-          production: false
-          url: https://example.com/${{ github.ref }}
-          environment: pr-selftest-fast-timeout
-          wait-timeout: 2s
+          wait-timeout: 10s # Just to fail in a reasonable amount of time

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -29,7 +29,8 @@ jobs:
           namespace: github-actions
           deployment: www
           container: nginx
-          image: nginx:latest
+          # image: nginx:latest
+          image: ghcr.io/firehed/deploy-to-kubernetes-action/server:${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           transient: ${{ github.event_name == 'pull_request' }}
           production: ${{ github.event_name == 'push' }}

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -90,6 +90,8 @@ jobs:
 
       - name: ${{ matrix.name }}
         uses: ./
+        id: test
+        continue-on-error: true
         with:
           namespace: ${{ matrix.namespace || 'github-actions' }}
           container: nginx
@@ -100,3 +102,7 @@ jobs:
           transient: false
           production: false
           wait-timeout: 10s # Just to fail in a reasonable amount of time
+
+      - name: Failing step must fail
+        if: steps.test.outcome != 'failure'
+        run: exit 1

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -29,7 +29,6 @@ jobs:
           namespace: github-actions
           deployment: www
           container: nginx
-          # image: nginx:latest
           image: ghcr.io/firehed/deploy-to-kubernetes-action/server:${{ github.event.pull_request.head.sha || github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           transient: ${{ github.event_name == 'pull_request' }}
@@ -37,14 +36,19 @@ jobs:
           url: https://example.com/${{ github.ref }}
           environment: ${{ github.event_name == 'push' && 'production' || format('dev-{0}', github.ref) }}
 
-#       - name: Run w/out waiting
-#         uses: ./
-#         with:
-#           image: nginx:latest
-#           token: ${{ secrets.GITHUB_TOKEN }}
-#           url: https://example.com/${{ github.ref }}
-#           environment: pr-selftest-no-wait
-#           wait: false
+      - name: Run w/out waiting
+        uses: ./
+        with:
+          namespace: github-actions
+          deployment: fast-deploy
+          container: nginx
+          image: ghcr.io/firehed/deploy-to-kubernetes-action/server:${{ github.event.pull_request.head.sha || github.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          transient: ${{ github.event_name == 'pull_request' }}
+          production: ${{ github.event_name == 'push' }}
+          url: https://example.com/${{ github.ref }}
+          environment: ${{ github.event_name == 'push' && 'production' || format('dev-{0}', github.ref) }}
+          wait: false
 
 #       - name: Run w/ very fast timeout
 #         uses: ./

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -45,7 +45,7 @@ jobs:
           deployment: www
           image: nginx:latest
           token: ${{ secrets.GITHUB_TOKEN }}
-          environment: self-test-failing
+          environment: pr-selftest-nopermissions
 
       - name: Run w/ incorrect deployment
         if: always()
@@ -57,4 +57,32 @@ jobs:
           deployment: fake
           image: nginx:latest
           token: ${{ secrets.GITHUB_TOKEN }}
-          environment: self-test-failing
+          environment: pr-selftest-incorrectdeploy
+
+      - name: Run w/out waiting
+        uses: ./
+        with:
+          namespace: github-actions
+          deployment: www
+          container: nginx
+          image: nginx:latest
+          token: ${{ secrets.GITHUB_TOKEN }}
+          transient: false
+          production: false
+          url: https://example.com/${{ github.ref }}
+          environment: pr-selftest-no-wait
+          wait: false
+
+      - name: Run w/ very fast timeout
+        uses: ./
+        with:
+          namespace: github-actions
+          deployment: www
+          container: nginx
+          image: nginx:latest
+          token: ${{ secrets.GITHUB_TOKEN }}
+          transient: false
+          production: false
+          url: https://example.com/${{ github.ref }}
+          environment: pr-selftest-fast-timeout
+          wait-timeout: 2s

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -35,3 +35,25 @@ jobs:
           production: ${{ github.event_name == 'push' }}
           url: https://example.com/${{ github.ref }}
           environment: ${{ github.event_name == 'push' && 'production' || format('dev-{0}', github.ref) }}
+
+      - name: Run w/ insufficient permission
+        uses: ./
+        with:
+          # no namespace ~ auth not good
+          container: nginx
+          deployment: www
+          image: nginx:latest
+          token: ${{ secrets.GITHUB_TOKEN }}
+          environment: self-test-failing
+
+      - name: Run w/ incorrect deployment
+        if: always()
+        uses: ./
+        with:
+          # no namespace ~ auth not good
+          namespace: github-actions
+          container: nginx
+          deployment: fake
+          image: nginx:latest
+          token: ${{ secrets.GITHUB_TOKEN }}
+          environment: self-test-failing

--- a/AUTHENTICATION.md
+++ b/AUTHENTICATION.md
@@ -54,6 +54,13 @@ rules:
       - list
       - get
       - patch
+  # List replicasets. This is only necessary with `wait: true`
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - list
 ```
 
 ## Create a RoleBinding

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+# This is just to have dummy builds for self-testing
+FROM nginx:latest AS server
+ARG COMMIT
+RUN echo $COMMIT > /usr/share/nginx/html/index.html

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This action will run the `kubectl` commands to deploy an image to Kubernetes, an
 | `production` | no | (varies) | Boolean indicating if this is an environment users will interact with |
 | `transient` | no | (varies) | Boolean indicating if this is an environment that may go away in the future |
 | `url` | no | | URL for where the deployment is accessible |
+| `wait` | no | `true` | Whether to wait for the rollout to complete before finishing |
+| `wait-timeout` | no | `5m` | Maximum time to wait for the rollout. If this timeout is reached, the step will fail and the deployment will be marked as failed on GitHub. Ignored if `wait` is `false`. |
 
 ## Outputs
 
@@ -23,7 +25,20 @@ This action will run the `kubectl` commands to deploy an image to Kubernetes, an
 |---|---|
 | | |
 
+## Status tracking
+
+Starting in `v0.3.0`, this action will by default watch the rollout in the cluster and try to keep the status in GitHub in sync.
+If the rollout does not complete within the timeout window (`wait-timeout`), the Deployment will be marked as failed.
+It is advisable to tune the timeout based on your deployment circimstances; any value accepted by the `kubectl rollout status`'s `--timeout` flag will work (`3s`, `5m`, etc).
+
+Note: long deployments will result in increased billable time.
+To disable rollout tracking entirely, run this action with `wait: false`.
+This will cause the step to finish when the deployment command is _run_ without regard for completion or success (beyond the command failing outright), which was the default behavior in previous versions.
+If you deploy very frequently, your deployments take a long time, or are cost-sensitive, this may be a better choice for you.
+See [About billing for GitHub Actions](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions) for more info.
+
 ## Authentication
+
 This action uses `kubectl` internally to deploy images; you must already be authenticated to the cluster (and be using the correct context).
 
 Depending on a number of factors (e.g. managed vs self-run, which provder, etc.), this process can be cluster-specific.

--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,21 @@ inputs:
   url:
     description: URL of the environment.
     required: false
+  wait:
+    default: "true"
+    description: |
+      Wait for rollout to complete before finishing.
+      When true, this increases the accuracy of the Deployment statuses displayed on Github, but will result in a longer billable duration (this is basically `kubectl rollout status`).
+      When false, the deployment status will be updated when the _command_ finishes.
+      Defaults to `true`.
+    required: false
+  wait-timeout:
+    default: "5m"
+    description: |
+      Maximum time to wait for a deploy to finish before timing out.
+      A timeout will be set to "error".
+      Accepts any format usable by `kubectl rollout status`, e.g. `1s`, `3m`, `2h`.
+    required: false
 
 branding:
   color: blue

--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ inputs:
   wait-timeout:
     default: "5m"
     description: |
-      Maximum time to wait for a deploy to finish before timing out.
+      Maximum time to wait for a rollout to finish before timing out.
       A timeout will be set to "error".
       Accepts any format usable by `kubectl rollout status`, e.g. `1s`, `3m`, `2h`.
     required: false

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,7 @@ description: Deploy to Kubernetes and track the deployment in Github.
 
 inputs:
   namespace:
+    default: default
     description: |
       The Kubernetes Namespace that the Deployment is in.
       If omitted, the `--namespace` flag is not used and the default Kubernetes behavior will apply.

--- a/dist/index.js
+++ b/dist/index.js
@@ -7626,7 +7626,7 @@ async function createDeploymentStatus(deploymentId, state) {
         auto_inactive: true,
         environment_url,
     };
-    core.info(`Updating Github deployment status to ${state}`);
+    core.info(`Updating GitHub deployment status to ${state}`);
     const result = await ok.rest.repos.createDeploymentStatus(params);
     core.debug(JSON.stringify(result));
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -7802,8 +7802,7 @@ async function trackDeploymentProgress(deploymentId, deployInfo, kubectlStdout) 
         await createDeploymentStatus(deploymentId, 'success');
     }
     else {
-        await createDeploymentStatus(deploymentId, 'failure');
-        core.setFailed(result.stderr);
+        throw new Error(`Rollout failed after starting: ${result.stderr} [${result.exitCode}]`);
     }
 }
 run();

--- a/dist/index.js
+++ b/dist/index.js
@@ -7650,7 +7650,6 @@ async function run() {
             image: core.getInput('image'),
         };
         await core.group('Deploy', async () => deploy(deploymentId, deployInfo));
-        // await core.group('Update status', async () => post(deploymentId!))
     }
     catch (error) {
         // update to failed?
@@ -7723,7 +7722,7 @@ async function deploy(deploymentId, deployInfo) {
     }
     const wait = core.getBooleanInput('wait');
     if (wait) {
-        await trackDeploymentProgress(deploymentId, deployInfo, deploymentOutput.stdout);
+        await trackRolloutProgress(deploymentId, deployInfo, deploymentOutput.stdout);
     }
     else {
         // fire-and-forget: assume the command goes through. This reduces the
@@ -7745,8 +7744,11 @@ async function deploy(deploymentId, deployInfo) {
  * `in_progress`, then either `success` or `failed` depending on the outcome.
  * It can be skipped entirely (and should be, if the action is called with
  * `wait: false`).
+ *
+ * Note: rollout history applies to `Deployment`, `DaemonSet`, and
+ * `StatefulSet` resources. It appears unsupported for `CronJob`.
  */
-async function trackDeploymentProgress(deploymentId, deployInfo, kubectlStdout) {
+async function trackRolloutProgress(deploymentId, deployInfo, kubectlStdout) {
     // Immediately track into "in progress"
     await createDeploymentStatus(deploymentId, 'in_progress');
     // There's a bunch of parts around the `kubectl set image` that don't _quite_

--- a/dist/index.js
+++ b/dist/index.js
@@ -7719,7 +7719,7 @@ async function deploy(deploymentId, deployInfo) {
     core.debug(JSON.stringify(deploymentOutput));
     if (deploymentOutput.exitCode > 0) {
         // TODO: include stderr in this message.
-        throw new Error('kubectl deployment command failed');
+        throw new Error(`kubectl deployment command failed: ${deploymentOutput.stderr} [${deploymentOutput.exitCode}]`);
     }
     const wait = core.getBooleanInput('wait');
     if (wait) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -7797,12 +7797,13 @@ async function trackDeploymentProgress(deploymentId, deployInfo, kubectlStdout) 
     // Runs the command in "watch" mode. This will exit success after some period
     // of time if the deploy finishes, and will exit nonzero if it fails, times
     // out, or has some other problem.
-    const exitCode = await exec.exec('kubectl', rolloutStatusArgs, { ignoreReturnCode: true });
-    if (exitCode === 0) {
+    const result = await exec.getExecOutput('kubectl', rolloutStatusArgs, { ignoreReturnCode: true });
+    if (result.exitCode === 0) {
         await createDeploymentStatus(deploymentId, 'success');
     }
     else {
         await createDeploymentStatus(deploymentId, 'failure');
+        core.setFailed(result.stderr);
     }
 }
 run();

--- a/dist/index.js
+++ b/dist/index.js
@@ -7626,6 +7626,7 @@ async function createDeploymentStatus(deploymentId, state) {
         auto_inactive: true,
         environment_url,
     };
+    core.info(`Updating Github deployment status to ${state}`);
     const result = await ok.rest.repos.createDeploymentStatus(params);
     core.debug(JSON.stringify(result));
 }
@@ -7641,7 +7642,7 @@ async function run() {
         await core.group('Check environment setup', envCheck);
         // const previousDeploymentId = await core.group('Finding previous deployment', findPreviousDeployment)
         // core.info(`Previous deployment: ${previousDeploymentId}`)
-        deploymentId = await core.group('Set up Github deployment', createDeployment);
+        deploymentId = await core.group('Set up GitHub deployment', createDeployment);
         const deployInfo = {
             namespace: core.getInput('namespace'),
             deployment: core.getInput('deployment'),
@@ -7696,7 +7697,7 @@ async function createDeployment() {
     core.debug(JSON.stringify(deploy));
     // @ts-ignore
     const deploymentId = deploy.data.id;
-    core.info(`Created deployment ${deploymentId}`);
+    core.info(`Created GitHub deployment ${deploymentId}`);
     // Immediately set the deployment to pending; it defaults to queued
     await createDeploymentStatus(deploymentId, 'pending');
     return deploymentId;
@@ -7732,7 +7733,7 @@ async function deploy(deploymentId, deployInfo) {
 }
 /**
  * This is a wrapper around the `kubectl rollout status` command to watch the
- * deployment and attempt to keep the Kubernetes status in sync with Github.
+ * deployment and attempt to keep the Kubernetes status in sync with GitHub.
  *
  * In an ideal world, this would be managed by some sort of webhook where K8S
  * sends a request to GH, but I'm unaware of a reasonably straightforward way

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -49,6 +49,7 @@ export async function createDeploymentStatus(deploymentId: number, state: Deploy
     auto_inactive: true,
     environment_url,
   }
+  core.info(`Updating Github deployment status to ${state}`)
   const result = await ok.rest.repos.createDeploymentStatus(params)
   core.debug(JSON.stringify(result))
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -22,3 +22,33 @@ export function getOctokit() {
 export function getTargetEnvironment(): string {
   return core.getInput('environment')
 }
+
+// These are declared roughly in order of state flow
+type DeploymentStatusStates =
+  | 'queued'
+  | 'pending'
+  | 'in_progress'
+  | 'success'
+  | 'error'
+  | 'failure'
+  | 'inactive'
+
+export async function createDeploymentStatus(deploymentId: number, state: DeploymentStatusStates): Promise<void> {
+  const ok = getOctokit()
+
+  let environment_url: string | undefined = core.getInput('url')
+  if (environment_url === '') {
+    environment_url = undefined
+  }
+
+  const params = {
+    owner: github.context.repo.owner,
+    repo: github.context.repo.repo,
+    deployment_id: deploymentId,
+    state,
+    auto_inactive: true,
+    environment_url,
+  }
+  const result = await ok.rest.repos.createDeploymentStatus(params)
+  core.debug(JSON.stringify(result))
+}

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -49,7 +49,7 @@ export async function createDeploymentStatus(deploymentId: number, state: Deploy
     auto_inactive: true,
     environment_url,
   }
-  core.info(`Updating Github deployment status to ${state}`)
+  core.info(`Updating GitHub deployment status to ${state}`)
   const result = await ok.rest.repos.createDeploymentStatus(params)
   core.debug(JSON.stringify(result))
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ async function createDeployment(): Promise<number> {
   core.info(`Created deployment ${deploymentId}`)
 
   // Immediately set the deployment to pending; it defaults to queued
-  createDeploymentStatus(deploymentId, 'pending')
+  await createDeploymentStatus(deploymentId, 'pending')
   return deploymentId
 }
 async function deploy(deploymentId: number): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,8 +203,7 @@ async function trackDeploymentProgress(
   if (result.exitCode === 0) {
     await createDeploymentStatus(deploymentId, 'success')
   } else {
-    await createDeploymentStatus(deploymentId, 'failure')
-    core.setFailed(result.stderr)
+    throw new Error(`Rollout failed after starting: ${result.stderr} [${result.exitCode}]`)
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {
   getRef,
 } from './helpers'
 
-type DeploymentId = number // Github's identifier
+type DeploymentId = number // GitHub's identifier
 
 interface DeployInfo {
   namespace: string
@@ -24,7 +24,7 @@ async function run(): Promise<void> {
     await core.group('Check environment setup', envCheck)
     // const previousDeploymentId = await core.group('Finding previous deployment', findPreviousDeployment)
     // core.info(`Previous deployment: ${previousDeploymentId}`)
-    deploymentId = await core.group('Set up Github deployment', createDeployment)
+    deploymentId = await core.group('Set up GitHub deployment', createDeployment)
     const deployInfo: DeployInfo = {
       namespace: core.getInput('namespace'),
       deployment: core.getInput('deployment'),
@@ -85,7 +85,7 @@ async function createDeployment(): Promise<DeploymentId> {
 
   // @ts-ignore
   const deploymentId: number = deploy.data.id
-  core.info(`Created deployment ${deploymentId}`)
+  core.info(`Created GitHub deployment ${deploymentId}`)
 
   // Immediately set the deployment to pending; it defaults to queued
   await createDeploymentStatus(deploymentId, 'pending')
@@ -126,7 +126,7 @@ async function deploy(deploymentId: DeploymentId, deployInfo: DeployInfo): Promi
 
 /**
  * This is a wrapper around the `kubectl rollout status` command to watch the
- * deployment and attempt to keep the Kubernetes status in sync with Github.
+ * deployment and attempt to keep the Kubernetes status in sync with GitHub.
  *
  * In an ideal world, this would be managed by some sort of webhook where K8S
  * sends a request to GH, but I'm unaware of a reasonably straightforward way

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,19 +3,12 @@ import * as exec from '@actions/exec'
 import * as github from '@actions/github'
 
 import {
+  createDeploymentStatus,
   getTargetEnvironment,
   getOctokit,
   getRef,
 } from './helpers'
 
-type DeploymentStatusStates =
-  | 'error'
-  | 'failure'
-  | 'inactive'
-  | 'in_progress'
-  | 'queued'
-  | 'pending'
-  | 'success'
 
 async function run(): Promise<void> {
   let deploymentId: number|undefined = undefined
@@ -139,26 +132,6 @@ async function deploy(deploymentId: number): Promise<void> {
   }
 
   await createDeploymentStatus(deploymentId, 'success')
-}
-
-async function createDeploymentStatus(deploymentId: number, state: DeploymentStatusStates): Promise<void> {
-  const ok = getOctokit()
-
-  let environment_url: string | undefined = core.getInput('url')
-  if (environment_url === '') {
-    environment_url = undefined
-  }
-
-  const params = {
-    owner: github.context.repo.owner,
-    repo: github.context.repo.repo,
-    deployment_id: deploymentId,
-    state,
-    auto_inactive: true,
-    environment_url,
-  }
-  const result = await ok.rest.repos.createDeploymentStatus(params)
-  core.debug(JSON.stringify(result))
 }
 
 run()

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,7 +107,8 @@ async function deploy(deploymentId: number): Promise<void> {
 
   await createDeploymentStatus(deploymentId, 'in_progress')
   // Run the actual deployment command
-  const deploymentOutput = await exec.getExecOutput('kubectl', args)
+  // TODO: figure out how to control output logging
+  const deploymentOutput = await exec.getExecOutput('kubectl', args, { ignoreReturnCode: true })
   core.debug(JSON.stringify(deploymentOutput))
   if (deploymentOutput.exitCode > 0) {
     throw new Error('kubectl deployment command failed')

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,12 +198,13 @@ async function trackDeploymentProgress(
   // Runs the command in "watch" mode. This will exit success after some period
   // of time if the deploy finishes, and will exit nonzero if it fails, times
   // out, or has some other problem.
-  const exitCode = await exec.exec('kubectl', rolloutStatusArgs, { ignoreReturnCode: true })
+  const result = await exec.getExecOutput('kubectl', rolloutStatusArgs, { ignoreReturnCode: true })
 
-  if (exitCode === 0) {
+  if (result.exitCode === 0) {
     await createDeploymentStatus(deploymentId, 'success')
   } else {
     await createDeploymentStatus(deploymentId, 'failure')
+    core.setFailed(result.stderr)
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,14 @@ import {
   getRef,
 } from './helpers'
 
+type DeploymentId = number // Github's identifier
+
+interface DeployInfo {
+  namespace: string
+  deployment: string
+  container: string
+  image: string
+}
 
 async function run(): Promise<void> {
   let deploymentId: number|undefined = undefined
@@ -38,7 +46,7 @@ async function envCheck(): Promise<void> {
   // try to provide helpful messages if not in a usable state
 }
 
-async function createDeployment(): Promise<number> {
+async function createDeployment(): Promise<DeploymentId> {
   const ok = getOctokit()
 
   let ref = core.getInput('ref')
@@ -76,7 +84,8 @@ async function createDeployment(): Promise<number> {
   await createDeploymentStatus(deploymentId, 'pending')
   return deploymentId
 }
-async function deploy(deploymentId: number): Promise<void> {
+
+async function deploy(deploymentId: DeploymentId): Promise<void> {
   const args = [
     'set',
     'image',

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,16 +18,20 @@ type DeploymentStatusStates =
   | 'success'
 
 async function run(): Promise<void> {
+  let deploymentId: number|undefined = undefined
   try {
     await core.group('Check environment setup', envCheck)
     // const previousDeploymentId = await core.group('Finding previous deployment', findPreviousDeployment)
     // core.info(`Previous deployment: ${previousDeploymentId}`)
-    const deploymentId = await core.group('Set up Github deployment', createDeployment)
+    deploymentId = await core.group('Set up Github deployment', createDeployment)
     await core.group('Deploy', deploy)
-    await core.group('Update status', async () => post(deploymentId))
+    await core.group('Update status', async () => post(deploymentId!))
   } catch (error) {
     // update to failed?
     core.setFailed(error.message)
+    if (deploymentId) {
+      await createDeploymentStatus(deploymentId, 'failure')
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,13 +124,17 @@ async function deploy(deploymentId: number): Promise<void> {
   const timeout = core.getInput('wait-timeout')
 
   if (wait) {
-    await exec.exec('kubectl', [
+    const rolloutStatusArgs = [
       'rollout',
       'status',
-      `deployment/${deployment}`,
-      `--revision=${revision}`,
-      `--timeout=${timeout}`,
-    ])
+    ]
+    if (namespace !== '') {
+      rolloutStatusArgs.push(`--namespace=${namespace}`)
+    }
+    rolloutStatusArgs.push(`deployment/${deployment}`)
+    rolloutStatusArgs.push(`--revision=${revision}`)
+    rolloutStatusArgs.push(`--timeout=${timeout}`)
+    await exec.exec('kubectl', rolloutStatusArgs)
     // TODO: if nonzero, set to failed
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,14 @@ async function run(): Promise<void> {
     // const previousDeploymentId = await core.group('Finding previous deployment', findPreviousDeployment)
     // core.info(`Previous deployment: ${previousDeploymentId}`)
     deploymentId = await core.group('Set up Github deployment', createDeployment)
-    await core.group('Deploy', async () => deploy(deploymentId!))
+    const deployInfo: DeployInfo = {
+      namespace: core.getInput('namespace'),
+      deployment: core.getInput('deployment'),
+      container: core.getInput('container'),
+      image: core.getInput('image'),
+    }
+
+    await core.group('Deploy', async () => deploy(deploymentId!, deployInfo))
     // await core.group('Update status', async () => post(deploymentId!))
   } catch (error) {
     // update to failed?
@@ -85,62 +92,119 @@ async function createDeployment(): Promise<DeploymentId> {
   return deploymentId
 }
 
-async function deploy(deploymentId: DeploymentId): Promise<void> {
+async function deploy(deploymentId: DeploymentId, deployInfo: DeployInfo): Promise<void> {
   const args = [
     'set',
     'image',
     'deployment',
+    `--namespace=${deployInfo.namespace}`,
+    deployInfo.deployment,
+    `${deployInfo.container}=${deployInfo.image}`,
+    '--record=true',
+    '--output=json', // This allows getting the new revision from the response to watch the rollout
   ]
 
-  const namespace = core.getInput('namespace')
-  if (namespace !== '') {
-    args.push(`--namespace=${namespace}`)
-  }
-
-  const deployment = core.getInput('deployment')
-  args.push(deployment)
-
-  const container = core.getInput('container')
-  const image = core.getInput('image')
-  args.push(`${container}=${image}`)
-
-  args.push('--record=true')
-  args.push('--output=json') // This allows getting the new revision from the response to watch the rollout
-
-  await createDeploymentStatus(deploymentId, 'in_progress')
   // Run the actual deployment command
   // TODO: figure out how to control output logging
   const deploymentOutput = await exec.getExecOutput('kubectl', args, { ignoreReturnCode: true })
   core.debug(JSON.stringify(deploymentOutput))
   if (deploymentOutput.exitCode > 0) {
+    // TODO: include stderr in this message.
     throw new Error('kubectl deployment command failed')
   }
 
-
-  // Parse response; wait for k8s to complete if desired
-  const deploymentStatus = JSON.parse(deploymentOutput.stdout)
-  const revision = deploymentStatus.metadata.annotations['deployment.kubernetes.io/revision']
-  core.debug(revision)
-
   const wait = core.getBooleanInput('wait')
-  const timeout = core.getInput('wait-timeout')
-
   if (wait) {
-    const rolloutStatusArgs = [
-      'rollout',
-      'status',
-    ]
-    if (namespace !== '') {
-      rolloutStatusArgs.push(`--namespace=${namespace}`)
-    }
-    rolloutStatusArgs.push(`deployment/${deployment}`)
-    rolloutStatusArgs.push(`--revision=${revision}`)
-    rolloutStatusArgs.push(`--timeout=${timeout}`)
-    await exec.exec('kubectl', rolloutStatusArgs)
-    // TODO: if nonzero, set to failed
+    await trackDeploymentProgress(deploymentId, deployInfo, deploymentOutput.stdout)
+  } else {
+    // fire-and-forget: assume the command goes through. This reduces the
+    // (billable!) runtime of the action, at the expense of GH status accuracy.
+    await createDeploymentStatus(deploymentId, 'success')
   }
 
-  await createDeploymentStatus(deploymentId, 'success')
+}
+
+/**
+ * This is a wrapper around the `kubectl rollout status` command to watch the
+ * deployment and attempt to keep the Kubernetes status in sync with Github.
+ *
+ * In an ideal world, this would be managed by some sort of webhook where K8S
+ * sends a request to GH, but I'm unaware of a reasonably straightforward way
+ * to accomplish this (it may be possible through some sort of Admission
+ * Controller, but that makes using this action WAY more complex and probably
+ * less reliable).
+ *
+ * This step will move the deployment (which should start as `pending`) to
+ * `in_progress`, then either `success` or `failed` depending on the outcome.
+ * It can be skipped entirely (and should be, if the action is called with
+ * `wait: false`).
+ */
+async function trackDeploymentProgress(
+  deploymentId: DeploymentId,
+  deployInfo: DeployInfo,
+  kubectlStdout: string,
+): Promise<void> {
+  // Immediately track into "in progress"
+  await createDeploymentStatus(deploymentId, 'in_progress')
+
+  // There's a bunch of parts around the `kubectl set image` that don't _quite_
+  // fit together nicely with `kubectl rollout history`, so this needs to patch
+  // over some ugliness:
+  //
+  // - If rollout history is run without the `revision` flag, it can start
+  // tracking a different rollout if one starts before the next finishes. While
+  // this can be avoided with GHA's `concurrency` option, there's no way to
+  // prevent this from external actors.
+  //
+  // - The revision flag's value doesn't seem to reliably come anywhere in the
+  // output of the deployment update's output. Trying to get it with `rollout
+  // history` creates a race condition, again with external actors.
+  //
+  // - If, for some reason, `set image deployment` changes nothing at all,
+  // there's nothing returned from the command at all - it simply exits 0 with
+  // no output on stdout.
+
+  let revision: number
+
+  if (kubectlStdout === '') {
+    // There was no change to the deployment. No great choice here but to grab
+    // the most recent rollout and hope we don't hit a race condition.
+    const historyResult = await exec.getExecOutput('kubectl', [
+      'rollout',
+      'history',
+      '--namespace', deployInfo.namespace,
+      'deployment', deployInfo.deployment,
+      '--output', 'json',
+    ])
+    const history = JSON.parse(historyResult.stdout)
+    revision = parseInt(history.metadata.annotations['deployment.kubernetes.io/revision'], 10)
+    core.debug(`Pulled revision from rollout history: ${revision}`)
+  } else {
+    const deploymentStatus = JSON.parse(kubectlStdout)
+  // This appears to return the OLD revision. Bump it by 1.
+    revision = parseInt(deploymentStatus.metadata.annotations['deployment.kubernetes.io/revision'], 10) + 1
+    core.debug(`Calculated revision from set image: ${revision}`)
+  }
+
+  const rolloutStatusArgs = [
+    'rollout',
+    'status',
+    '--namespace', deployInfo.namespace,
+    'deployment', deployInfo.deployment,
+    '--revision', `${revision}`,
+    '--timeout', core.getInput('wait-timeout'),
+  ]
+
+  // Runs the command in "watch" mode. This will exit success after some period
+  // of time if the deploy finishes, and will exit nonzero if it fails, times
+  // out, or has some other problem.
+  const exitCode = await exec.exec('kubectl', rolloutStatusArgs, { ignoreReturnCode: true })
+
+  if (exitCode === 0) {
+    await createDeploymentStatus(deploymentId, 'success')
+  } else {
+    await createDeploymentStatus(deploymentId, 'failure')
+  }
 }
 
 run()

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ async function deploy(deploymentId: DeploymentId, deployInfo: DeployInfo): Promi
   core.debug(JSON.stringify(deploymentOutput))
   if (deploymentOutput.exitCode > 0) {
     // TODO: include stderr in this message.
-    throw new Error('kubectl deployment command failed')
+    throw new Error(`kubectl deployment command failed: ${deploymentOutput.stderr} [${deploymentOutput.exitCode}]`)
   }
 
   const wait = core.getBooleanInput('wait')

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,6 @@ async function run(): Promise<void> {
     }
 
     await core.group('Deploy', async () => deploy(deploymentId!, deployInfo))
-    // await core.group('Update status', async () => post(deploymentId!))
   } catch (error) {
     // update to failed?
     core.setFailed(error.message)
@@ -115,7 +114,7 @@ async function deploy(deploymentId: DeploymentId, deployInfo: DeployInfo): Promi
 
   const wait = core.getBooleanInput('wait')
   if (wait) {
-    await trackDeploymentProgress(deploymentId, deployInfo, deploymentOutput.stdout)
+    await trackRolloutProgress(deploymentId, deployInfo, deploymentOutput.stdout)
   } else {
     // fire-and-forget: assume the command goes through. This reduces the
     // (billable!) runtime of the action, at the expense of GH status accuracy.
@@ -138,8 +137,11 @@ async function deploy(deploymentId: DeploymentId, deployInfo: DeployInfo): Promi
  * `in_progress`, then either `success` or `failed` depending on the outcome.
  * It can be skipped entirely (and should be, if the action is called with
  * `wait: false`).
+ *
+ * Note: rollout history applies to `Deployment`, `DaemonSet`, and
+ * `StatefulSet` resources. It appears unsupported for `CronJob`.
  */
-async function trackDeploymentProgress(
+async function trackRolloutProgress(
   deploymentId: DeploymentId,
   deployInfo: DeployInfo,
   kubectlStdout: string,


### PR DESCRIPTION
Adds a `wait` input (default: `true`) which when set will cause the action to monitor the progress of the rollout and update the Deployment status at GitHub accordingly before completing.

Fixes #17.